### PR TITLE
Refactor paths to use relative directories for portability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# User and Group IDs - Run 'id' command to get your values
+JELLYFIN_UID=1000
+JELLYFIN_GID=1000
+QBITTORENT_PUID=1000
+QBITTORENT_PGID=1000
+SONARR_PUID=1000
+SONARR_PGID=1000
+RADARR_PUID=1000
+RADARR_PGID=1000
+
+# Timezone - Set your local timezone
+TZ=Asia/Colombo
+
+# Jellyfin Settings
+JELLYFIN_PUBLISHED_URL=JELLYFIN_PublishedServerUrl=http://127.0.0.1:8096
+
+# qBittorrent Settings
+QBITTORENT_WEBUI_PORT=8080
+QBITTORENT_TORRENTING_PORT=6881
+
+# Sonarr Port
+SONARR_PORT=8989
+
+# Radarr Port  
+RADARR_PORT=7878
+
+# Prowlarr Port
+PROWLARR_PORT=9696
+
+# Uptime Kuma Port
+UPTIMEKUMA_PORT=3001

--- a/README.md
+++ b/README.md
@@ -4,42 +4,93 @@ This homelab runs on a **256 GB Linux server** using **Docker** and
 **Docker Compose** for container management.\
 Everything is organized with **persistent storage** and a single main
 `docker-compose.yml` file for smooth deployment and updates.\
-*It's a work in progress --- continuously improving, tweaking, and
-adding new services!* 🔧✨
+_It's a work in progress --- continuously improving, tweaking, and
+adding new services!_ 🔧✨
 
-------------------------------------------------------------------------
+---
 
 ## **⚡ Services running via Docker Compose**
 
--   🎬 **Jellyfin** -- self-hosted media server for movies, music, and
-    TV shows\
--   🌊 **qBittorrent** -- torrent client with a clean web interface for
-    remote management\
--   📈 **Uptime Kuma** -- lightweight monitoring to keep an eye on
-    service health\
--   📺 **Sonarr** -- automated TV series management and downloading\
--   🎥 **Radarr** -- automated movie management and downloading\
--   🔎 **Prowlarr** -- indexer manager for Sonarr, Radarr, and other
-    download apps
+- 🎬 **Jellyfin** -- self-hosted media server for movies, music, and
+  TV shows\
+- 🌊 **qBittorrent** -- torrent client with a clean web interface for
+  remote management\
+- 📈 **Uptime Kuma** -- lightweight monitoring to keep an eye on
+  service health\
+- 📺 **Sonarr** -- automated TV series management and downloading\
+- 🎥 **Radarr** -- automated movie management and downloading\
+- 🔎 **Prowlarr** -- indexer manager for Sonarr, Radarr, and other
+  download apps
 
-------------------------------------------------------------------------
+---
+
+## **🚀 Quick Setup**
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone https://github.com/rakithat20/home-lab.git
+   cd home-lab
+   ```
+
+2. **Configure environment variables**:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Edit `.env` and update:
+
+   - User/Group IDs (run `id` command to get your values)
+   - Timezone (default: `Asia/Colombo`)
+   - Ports (if needed)
+
+3. **Start services**:
+   ```bash
+   docker-compose up -d
+   ```
 
 ## **📂 Directory Structure**
 
--   **`apps/`** → persistent configuration for each service (`JellyFin`,
-    `qBittorrent`, `uptimekuma`, `sonarr`, `radarr`, `prowlarr`)\
--   **`home-lab/docker-compose.yml`** → central file to manage all
-    containers\
--   **`home-lab/README.md`** → documentation for the homelab\
--   **`sambashare/`** → shared storage for media files (`Movies`,
-    `Music`, `TV_Shows`)\
--   **`Downloads/`** → temporary files and utilities
+After first run, the following structure will be created:
 
-------------------------------------------------------------------------
+```
+home-lab/
+├── docker-compose.yml     → main container configuration
+├── .env                  → your environment variables
+├── data/                 → persistent app configurations
+│   ├── jellyfin/
+│   ├── qbittorrent/
+│   ├── sonarr/
+│   ├── radarr/
+│   ├── prowlarr/
+│   └── uptimekuma/
+└── media/                → your media files
+    ├── movies/
+    └── tv/
+```
+
+---
+
+## **🌐 Access Your Services**
+
+Once running, access services at:
+
+- **Jellyfin**: `http://localhost:8096`
+- **qBittorrent**: `http://localhost:8080`
+- **Sonarr**: `http://localhost:8989`
+- **Radarr**: `http://localhost:7878`
+- **Prowlarr**: `http://localhost:9696`
+- **Uptime Kuma**: `http://localhost:3001`
+
+_(Ports can be customized in your `.env` file)_
+
+---
 
 ## **Why this setup?**
 
 This homelab is designed to be:\
+
 - **Simple** → one compose file to rule them all 🗂️\
 - **Maintainable** → clear data separation for easy backup\
 - **Scalable** → ready to grow with new services as I experiment 🌱

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     user: ${JELLYFIN_UID}:${JELLYFIN_GID}
     network_mode: 'host'
     volumes:
-      - /home/rakitha/apps/JellyFin/config:/config
-      - /home/rakitha/apps/JellyFin/cache:/cache
+      - ./data/jellyfin/config:/config
+      - ./data/jellyfin/cache:/cache
       - type: bind
-        source: /home/rakitha/sambashare
+        source: ./media
         target: /media
       
     restart: 'unless-stopped'
@@ -30,8 +30,8 @@ services:
       - TORRENTING_PORT=${QBITTORENT_TORRENTING_PORT}
 
     volumes:
-      - /home/rakitha/apps/qbittorrent/config:/config
-      - /home/rakitha/apps/qbittorrent/downloads:/downloads
+      - ./data/qbittorrent/config:/config
+      - ./data/qbittorrent/downloads:/downloads
     ports:
       - "${QBITTORENT_WEBUI_PORT}:9090"
       - "${QBITTORENT_TORRENTING_PORT}:6881"
@@ -45,9 +45,9 @@ services:
       - PGID=${SONARR_PGID}
       - TZ=${TZ}
     volumes:
-      - /home/rakitha/apps/sonarr/data:/config
-      - /home/rakitha/sambashare/Tv_Shows:/tv
-      - /home/rakitha/apps/qbittorrent/downloads:/downloads
+      - ./data/sonarr/config:/config
+      - ./media/tv:/tv
+      - ./data/qbittorrent/downloads:/downloads
     ports:
       - "${SONARR_PORT}:8989"
     restart: unless-stopped
@@ -62,9 +62,9 @@ services:
       - PGID=${RADARR_PGID}
       - TZ=${TZ}
     volumes:
-      - /home/rakitha/apps/radarr/data:/config
-      - /home/rakitha/sambashare/Movies:/movies
-      - /home/rakitha/apps/qbittorrent/downloads:/downloads
+      - ./data/radarr/config:/config
+      - ./media/movies:/movies
+      - ./data/qbittorrent/downloads:/downloads
     ports:
       - "${RADARR_PORT}:7878"
     restart: unless-stopped
@@ -79,14 +79,14 @@ services:
       - PGID=${SONARR_PGID}
       - TZ=${TZ}
     volumes:
-      - /home/rakitha/apps/prowlarr/data:/config
+      - ./data/prowlarr/config:/config
     ports:
       - "${PROWLARR_PORT}:9696"
     restart: unless-stopped
   uptimekuma:
     image: louislam/uptime-kuma:latest
     volumes: 
-      - /home/rakitha/apps/uptimekuma:/app/data
+      - ./data/uptimekuma:/app/data
     container_name: uptime-kuma
     ports:
       - "${UPTIMEKUMA_PORT}:3001"


### PR DESCRIPTION
## Summary
  - Replace hardcoded personal paths (`/home/rakitha/`) with relative paths (`./data/`, `./media/`)
  - Add comprehensive `.env.example` file with all required environment variables
  - Update README.md with clear setup instructions and new directory structure

  ## Changes Made
  - **docker-compose.yml**: All volume mounts now use relative paths for portability
  - **`.env.example`**: Added with default values, timezone set to Asia/Colombo, and helpful comments
  - **README.md**: Updated with quick setup guide, new directory structure, and service access URLs

  ## Benefits
  - Repository is now portable and works on any system without modification
  - Users can easily configure their own environment without editing the compose file
  - Clear documentation makes setup straightforward for new users
  - Maintains all existing functionality while improving usability